### PR TITLE
Desveteranizar al Clown, al Mimo y la raza Caracol

### DIFF
--- a/modular_nova_hispania/modules/veteran_only/code/job_types.dm
+++ b/modular_nova_hispania/modules/veteran_only/code/job_types.dm
@@ -1,0 +1,5 @@
+/datum/job/clown
+	veteran_only = FALSE
+
+/datum/job/mime
+    veteran_only = FALSE

--- a/modular_nova_hispania/modules/veteran_only/code/species_types.dm
+++ b/modular_nova_hispania/modules/veteran_only/code/species_types.dm
@@ -1,0 +1,2 @@
+/datum/species/snail
+	veteran_only = FALSE

--- a/modular_nova_hispania/modules/veteran_only/readme.md
+++ b/modular_nova_hispania/modules/veteran_only/readme.md
@@ -1,0 +1,28 @@
+## Title: Veteran Only Overrides
+
+MODULE ID: VETERAN_ONLY
+
+### Description:
+
+Overrides or extends /tg/ definitions with veteran only requirements.
+
+As of module creation, there are no veteran_only overrides remaining in the master files.
+
+### TG Proc Changes:
+
+- N/A
+
+### Defines:
+
+- N/A
+
+### Master file additions
+
+- None!
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+- N/A

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8327,4 +8327,6 @@
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\sentinel.dm"
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\spitter.dm"
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\warrior.dm"
+#include "modular_nova_hispania\modules\veteran_only\code\job_types.dm"
+#include "modular_nova_hispania\modules\veteran_only\code\species_types.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

Clown, mimo y caracol dejan de ser parte del sistema de veteranos y se deja abierta al publico.

## How This Contributes To The Nova Sector Roleplay Experience

Ahora pueden ser usados por todo el mundo de manera correcta.

## Proof of Testing

Desactivando desde la configuración ENABLE_LOCALHOST_RANK para poder acceder como un usuario normal, se muestran correctamente el blueshield y el NTREP bloqueados por la restricción, pero el mimo y el clown son accesibles.

![al fin](https://github.com/HispaniaSpaceStation13/NovaHispania/assets/40409324/6af58794-e0f8-4d15-a558-d1786b268ff9)

## Changelog

:cl:
config: Clown, mimo y caracol públicos
/:cl:
